### PR TITLE
Restrict master pushes to reviewers.

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -105,7 +105,9 @@ branches:
       # Required. Restrict who can push to this branch. Team and user
       # restrictions are only available for organization-owned repositories.
       # Set to null to disable.
-      restrictions: null
+      restrictions:
+        teams:
+          - reviewers
 
       # Permits force pushes to the protected branch by anyone with write access
       # to the repository. Set to true to allow force pushes. Set to false or


### PR DESCRIPTION
We allow certain bot users "push" access to repos, which means they can
create branches and releases, but we don't want them to ever push to
master.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/template/8)
<!-- Reviewable:end -->
