### PR TITLE
Add push access for admins.

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -45,7 +45,7 @@ repository:
 
 teams:
   - name: admins
-    permission: pull
+    permission: push
   - name: automation
     permission: push
   - name: contributors


### PR DESCRIPTION
"maintain" apparently doesn't work. It's also not really needed given
that they can make changes to the settings file.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/template/10)
<!-- Reviewable:end -->
