### PR TITLE
Rename "template" repo to ".github".

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -1,10 +1,10 @@
 ---
 repository:
   # The name of the repository. Changing this will rename the repository
-  name: template
+  name: .github
 
   # A short description of the repository that will show up on GitHub
-  description: Template repository for setting up a new project within TokTok
+  description: Global settings for all TokTok repos.
 
   # A URL with more information about the repository
   homepage: https://toktok.ltd/

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,0 +1,3 @@
+load("//tools/project:build_defs.bzl", "project")
+
+project()

--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,7 @@
                     GNU GENERAL PUBLIC LICENSE
                        Version 3, 29 June 2007
 
- Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
  Everyone is permitted to copy and distribute verbatim copies
  of this license document, but changing it is not allowed.
 
@@ -645,7 +645,7 @@ the "copyright" line and a pointer to where the full notice is found.
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 Also add information on how to contact you by electronic and paper mail.
 
@@ -664,11 +664,12 @@ might be different; for a GUI interface, you would use an "about box".
   You should also get your employer (if you work as a programmer) or school,
 if any, to sign a "copyright disclaimer" for the program, if necessary.
 For more information on this, and how to apply and follow the GNU GPL, see
-<https://www.gnu.org/licenses/>.
+<http://www.gnu.org/licenses/>.
 
   The GNU General Public License does not permit incorporating your program
 into proprietary programs.  If your program is a subroutine library, you
 may consider it more useful to permit linking proprietary applications with
 the library.  If this is what you want to do, use the GNU Lesser General
 Public License instead of this License.  But first, please read
-<https://www.gnu.org/licenses/why-not-lgpl.html>.
+<http://www.gnu.org/philosophy/why-not-lgpl.html>.
+


### PR DESCRIPTION
This is the default for some apps and is actually required by some other
apps. Very sad.. this also means we can't have .github be a submodule
named .github at the top level of toktok-stack.

As a result, this repo will now sit in tools/.github, so it doesn't
conflict with the actual .github in toktok-stack.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/template/14)
<!-- Reviewable:end -->
