### PR TITLE
chore: Exempt dependabot from semantic release conventions.

### DIFF
--- a/.github/mergeable.yml
+++ b/.github/mergeable.yml
@@ -5,13 +5,17 @@ mergeable:
     validate:
       # Enforce semantic release convention.
       - do: title
-        must_include:
-          regex: ^(feat|docs|chore|cleanup|fix|refactor|test|style|perf)(\(\w+\))?:.+$
-          message: Semantic release conventions must be followed.
+        or:
+          - must_include:
+              regex: ^(feat|docs|chore|cleanup|fix|refactor|test|style|perf)(\(\w+\))?:.+$
+              message: Semantic release conventions must be followed.
+          - must_include:
+              regex: ^Bump [^ ]* from [^ ]* to [^ ]*$
+              message: Dependabot PRs are exempt from semantic release conventions.
       # All todo check boxes must be checked.
       - do: description
         must_exclude:
-          regex: \[ \]
+          regex: \\[ \\]
           message: There are incomplete TODO task(s) unchecked.
     pass:
       - do: checks


### PR DESCRIPTION
Dependabot already adds the "dependencies" label, so we don't need the
`chore(deps)` to make that happen.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/.github/22)
<!-- Reviewable:end -->
