### PR TITLE
feat: Add an invalid label to make sorting out undesirable PRs easier

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -229,6 +229,10 @@ labels:
     color: "#ffffff"
     description: "Won't Fix (Intended behaviour)"
 
+  - name: "invalid"
+    color: "#d73a49"
+    description: "Irrelevant or spam"
+
   #############################################################################
   #
   # :: Priority labels


### PR DESCRIPTION
Context: https://github.com/TokTok/website/pulls

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/.github/24)
<!-- Reviewable:end -->
