### PR TITLE
chore: Remove some status checks we don't need.

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -84,8 +84,6 @@ branches:
         # into this branch
         contexts:
           # Common across all repos.
-          - DeepCode
-          - Hound
           - Mergeable
           - Milestone Check
           - WIP


### PR DESCRIPTION
Not all repos need these, and they seem to be broken at the moment.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/.github/25)
<!-- Reviewable:end -->
