### PR TITLE
fix: Correct mergeable check for commit messages.

### DIFF
--- a/.github/mergeable.yml
+++ b/.github/mergeable.yml
@@ -14,10 +14,10 @@ mergeable:
               message: Dependabot PRs are exempt from semantic release conventions.
       - do: commit
         or:
-          - must_include:
+          - message:
               regex: ^(feat|docs|chore|cleanup|fix|refactor|test|style|perf)(\(\w+\))?:\ .+$
               message: Semantic release conventions must be followed.
-          - must_include:
+          - message:
               regex: ^Bump [^ ]* from [^ ]* to [^ ]*$
               message: Dependabot PRs are exempt from semantic release conventions.
       # All todo check boxes must be checked.


### PR DESCRIPTION
Or at least I think so?

https://mergeable.readthedocs.io/en/latest/validators/commit.html

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/.github/35)
<!-- Reviewable:end -->
